### PR TITLE
Task assignment updates.

### DIFF
--- a/NewABS/NewABS2.hs
+++ b/NewABS/NewABS2.hs
@@ -260,7 +260,9 @@ mainLoop = atomic $
      veloMem <- interRunnableVariable 0.0 
      state   <- interRunnableVariable S0
 
-     runnable (MinInterval 0) [TimingEvent deltaT] $ 
+     runnableT ["abs_mainloop_task" :-> 0] 
+               (MinInterval 0) 
+               [TimingEvent deltaT] $ 
        do velos  <- mapM (fmap fromOk . rteRead) velosIn
           Ok acc <- rteRead accelIn
           Ok s0  <- rteIrvRead state
@@ -406,6 +408,9 @@ absSystem = composition $
      let vs = map valve wheelCtrls
          ss = map slip  wheelCtrls
          is = map index wheelCtrls
+
+     declareTask "abs_mainloop_task" (TimingEvent 0.0015)
+
      return $ ABS (accelIn, zipWith3 WheelPorts velosIn vs is)
 
 instance External ABS where

--- a/NewARSim/NewARSim.hs
+++ b/NewARSim/NewARSim.hs
@@ -85,11 +85,6 @@ import qualified Test.QuickCheck.Text as QCT
 import qualified Test.QuickCheck.Exception as QCE
 import qualified Test.QuickCheck.State as QCS
 
--- Debug imports
--- XXX REMOVE
-import Debug.Trace
-import GHC.Stack
-
 -- The RTE monad -------------------------------------------------------------
 
 type RTE c a                = Program (RTEop c) a
@@ -194,7 +189,7 @@ data SimState = SimState
   , simProbes   :: [Probe]
   , initvals    :: Map Address Value
   , nextA       :: Address
-  , tasks       :: Map String [(Int, ProcAddress)]
+  , tasks       :: Map String [(Int, ProcAddress, Int)]
   , taskDecl    :: Map Address String
   }
 
@@ -330,7 +325,7 @@ apInit conn mp p = p
 
 -- | Decorate a @Task@ process with its state, and check that all tasks have
 -- been assigned runnables.
-taskInit :: HasCallStack => Map String [(Int, ProcAddress)]
+taskInit :: Map String [(Int, ProcAddress, Int)]
          -> Map Address String
          -> Proc
          -> Proc
@@ -339,7 +334,9 @@ taskInit tp na p@(Task a _ ts) =
   in  case Map.lookup name tp of
         Nothing -> error $ "Task " ++ show name ++ " was assigned no runnables."
         Just prios ->
-          let prios' = map snd $ sortBy (compare `on` fst) prios 
+          let fst3 (x, _, _) = x
+              pick (_, x, y) = (x, 0, y)
+              prios' = map pick $ sortBy (compare `on` fst3) prios 
           in  Task a Inactive ts 
                 { taskName  = name 
                 , execProcs = prios' 
@@ -348,7 +345,7 @@ taskInit _  _  p = p
 
 -- | Check that all tasks which have been assigned runnables also have been 
 -- declared.
-checkTasks :: Map String [(Int, ProcAddress)] -> Map Address String -> ()
+checkTasks :: Map String a -> Map b String -> ()
 checkTasks tp na = check na' tp' 
   where
     na' = Map.elems na
@@ -366,7 +363,7 @@ checkTasks tp na = check na' tp'
 -- Static task state.
 data TaskState = TaskState
   { taskName    :: String 
-  , execProcs   :: [ProcAddress] -- Address?
+  , execProcs   :: [(ProcAddress, Int, Int)] -- ^ @(addr, curr_skip, max_skip)@
   , taskTrigger :: Maybe Address
   } deriving Show
 
@@ -392,6 +389,14 @@ active (Task _ (Active _ (x:_)) ts) = show (taskName ts) ++ " expects " ++
                                       "NEW from " ++ show x
 active _                            = "NON_TASK"
 
+-- | Activate a task. Increments counters in the task state, and activates only
+-- those tasks which has a zero counter after state modification.
+activate :: Proc -> Proc
+activate (Task b _ ts) = Task b (Active True procs) ts { execProcs = next }
+  where
+    next  = map (\(a, n, m) -> (a, (n + 1) `mod` m, m)) (execProcs ts)
+    procs = [ addr | (addr, 0, _) <- next ]
+
 -- The AR monad ---------------------------------------------------------------
 
 data ARInstr c a where
@@ -405,9 +410,17 @@ data ARInstr c a where
     AssignTask    :: Address -> Task -> ARInstr c ()
     NewTask       :: String -> Address -> ARInstr c ()
 
---  ex: "my_task" :-> (my_prio :: Int)
 --  (T :-> x) < (T :-> y)   iff x < y
-data Task = String :-> Int
+-- | Task assignments can be made in two ways. @"my_task" :>> (p, s)@ maps the
+-- runnable to the task "my_task" with priority @p@, scheduling it every @s > 0@ 
+-- task activations. The @:->@ constructor is essentially a special case where 
+-- @s = 1@. Tasks are ordered on @p@ s.t. 
+--
+-- @T :-> x@ executes prior to @T :-> y@ iff @x < y@.
+data Task 
+  = String :-> Int        -- ^ @Task name :-> Priority@
+  | String :>> (Int, Int) -- ^ @Task name :>> (Priority, Skip)
+
   deriving (Eq, Ord, Show)
 
 type AR c a                 = Program (ARInstr c) a
@@ -440,8 +453,10 @@ runAR sys st                = run sys st
                             = run (sys ()) (st { conns = addTransitive conn (conns st) })
     run' (Return a) st      = (a,st)
 
-    run' (AssignTask a (s :-> p) :>>= sys) st 
-                            = run (sys ()) (st { tasks = Map.insertWith (++) s [(p, RunAddr a)] (tasks st) })
+    run' (AssignTask a (s :>> (p, n)) :>>= sys) st 
+      | n < 1 = error $ "Attempted to assign task " ++ show a ++ " with a" ++ 
+                        " non-positive skip parameter " ++ show n ++ "."
+      | otherwise = run (sys ()) (st { tasks = Map.insertWith (++) s [(p, RunAddr a, n)] (tasks st) })
     run' (NewTask n a :>>= sys) st 
                             = if n `elem` Map.elems (taskDecl st) then
                                 error $ "Task " ++ show n ++ " declared twice."
@@ -627,8 +642,7 @@ runnable :: Invocation -> [Event c] -> RTE c a -> Atomic c ()
 runnable = runnableT [] 
 
 -- | Task assigned runnable.
-runnableT :: HasCallStack
-          => [Task] 
+runnableT :: [Task] 
           -> Invocation 
           -> [Event c] 
           -> RTE c a 
@@ -718,9 +732,12 @@ probeWrite' s x f    = singleton $ NewProbe s g
 -}
 
 -- | Assign an address to a task.
--- XXX Not fixed
 assignTask :: Address -> Task -> AR c ()
-assignTask a (t :-> p) = singleton $ AssignTask a (t :-> p)
+assignTask a task =
+  singleton $ AssignTask a $
+    case task of 
+      t :-> p -> t :>> (p, 1)
+      _       -> task
 
 data Label                  = ENTER Address
                             | EXIT  Address
@@ -917,16 +934,13 @@ hear conn (TICK a)      (Run b t _ n m s f)   | a==b      = Update $ Run b t Pen
 hear conn (DELTA d)     (Run b 0.0 act n m s _)           = Unchanged 
 hear conn (DELTA d)     (Run b t act n m s f)             = Update $ Run b (t-d) act n m s f
 hear conn (DELTA d)     (Timer b t t0 n)                  = Update $ Timer b (t-d) t0 n
-hear conn (WR a v)      (Output b _)       | a `conn` b   = Update $ Output b v
-
--- Task triggering:
+hear conn (WR a v)      (Output b _)       
+        | a `conn` b                                      = Update $ Output b v
 hear conn (WR a _)      (Task b Inactive ts) 
-        | trigT conn a ts                                 = Update $ Task b (Active True (execProcs ts)) ts 
+        | trigT conn a ts                                 = Update $ activate (Task b Inactive ts)
 hear conn (SND a _ _)   (Task b Inactive ts) 
-        | trigT conn a ts                                 = Update $ Task b (Active True (execProcs ts)) ts
-hear conn (TICK a)      (Task b Inactive ts) | a == b     = Update $ Task b (Active True (execProcs ts)) ts
-
--- Tasks scheduling:
+        | trigT conn a ts                                 = Update $ activate (Task b Inactive ts)
+hear conn (TICK a)      (Task b Inactive ts) | a == b     = Update $ activate (Task b Inactive ts) 
 hear conn (NEW a n)     (Task b (Active True (x:xs)) ts) 
         | a `isRunning` x                                 = Update $ Task b (Active False (RInstAddr a n:xs)) ts
 hear conn (TERM a)      (Task b (Active False (x:xs)) ts)
@@ -955,7 +969,7 @@ step :: ConnRel -> ProcMap -> [SchedulerOption]
 step conn pm = explore conn pm procs sayers
   where
     procs     = pmapElems pm
-    sayers    = scheduled ++ tasks ++ untasked
+    sayers    = scheduled ++ untasked
     untasked  = filter isUntasked   procs
     tasks     = filter isActiveTask procs 
     scheduled = map (pmapLookup pm) $ mapMaybe schedIn tasks 
@@ -1000,12 +1014,6 @@ hear1 conn label pm =
     UP a _    -> [hear conn label (pmapLookup pm (UniqueAddr a))]
     RES a _   -> [hear conn label (pmapLookup pm (UniqueAddr a))]
     RET a _   -> [hear conn label (pmapLookup pm (UniqueAddr a))]
-
---     TERM a    -> [hear conn label (pmapLookup pm (RunAddr a))]
---     TICK a    -> [hear conn label (pmapLookup pm (RunAddr a))]
-
---  It would be possible to use applicative to try RunAddr first and then
---  UniqueAddr on some of these 
     -- Not on target
     CALL {}   -> map (hear conn label) (pmapElems pm)
     INV {}    -> map (hear conn label) (pmapElems pm)
@@ -1032,9 +1040,6 @@ response conn pm p h =
       UP a _   -> mayHear conn label (pmapLookup pm (UniqueAddr a))
       RES a _  -> mayHear conn label (pmapLookup pm (UniqueAddr a))
 
-      -- Try to find a task with the address @a@. If we dont find one,
-      -- we can safely leave the label as it is. (It's a bit expensive to
-      -- send these to /all/ processes).
       TICK a   -> 
         case Map.lookup (UniqueAddr a) pm of
           Just proc -> mayHear conn label proc
@@ -1046,8 +1051,7 @@ response conn pm p h =
       DELTA {} -> response' label 
       _        -> label
   where
-    response' = respond conn h -- (pmapElems (pmapDelete p pm))
---     response' = respond conn as . respond conn bs 
+    response' = respond conn h
 
 -- * Address-to-process
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1066,8 +1070,8 @@ pmapElems :: ProcMap -> [Proc]
 pmapElems = Map.elems
 
 -- | Lookup process by its address. 
-pmapLookup :: HasCallStack => ProcMap -> ProcAddress -> Proc
-pmapLookup pm pa = -- (Map.!)
+pmapLookup :: ProcMap -> ProcAddress -> Proc
+pmapLookup pm pa = 
   fromMaybe (error $ "Address " ++ show pa ++ " has no process.")
             (Map.lookup pa pm)
 
@@ -1076,11 +1080,11 @@ pmapInsert :: Proc -> ProcMap -> ProcMap
 pmapInsert p = Map.insert (procAddress p) p
 
 -- | Delete the (address, process) pair from the map.
-pmapDelete :: HasCallStack => Proc -> ProcMap -> ProcMap
+pmapDelete :: Proc -> ProcMap -> ProcMap
 pmapDelete = Map.delete . procAddress  
 
 -- | Bulk update of process map.
-pmapUpdate :: HasCallStack => ProcMap -> [Update Proc] -> ProcMap
+pmapUpdate :: ProcMap -> [Update Proc] -> ProcMap
 pmapUpdate pm ps = foldr pmapInsert (foldr pmapDelete pm removals) updates
   where
     updates  = [p | Update p <- ps]
@@ -1234,8 +1238,6 @@ simulate1 withTasks sched conn procs
 
 -- * External control of schedulers
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--- TODO: There is nothing in this section that would suffer from a good cleanup,
--- especially the functions which report warnings.
 
 -- Schedules work as long as work-steps are available. When no more work can be
 -- done, @DELTA@-steps are scheduled.
@@ -1286,7 +1288,7 @@ checkEarlyPending :: Monad m
 checkEarlyPending conn pm sched alts = do
   res <- sched alts
   let (label, us) = case res of 
-          -- Intended invariant: Some transition was made
+          -- Invariant: A transition was made, result is never @None@ 
           Warn w (trans, ps) -> (transLabel trans, ps)
           Some   (trans, ps) -> (transLabel trans, ps)
   case label of 
@@ -1299,8 +1301,9 @@ checkEarlyPending conn pm sched alts = do
       | null (pendTwice a us) = return res
       | otherwise             = return $ warn (errmsg a us) res
 
-    errmsg a us = "Runnables were triggered while Pending: " ++ 
-                  unwords (map (show . procAddress) (pendTwice a us))
+    errmsg a us = "*** Runnables were triggered while Pending: " ++ 
+                  unwords (map (show . procAddress) (pendTwice a us)) ++
+                  " ***" 
 
     affected a (Run b _ _ _ _ s _) = a == b || trig conn a s
     affected _ _                   = False
@@ -1895,18 +1898,20 @@ simulationExt fds sys idx_in idx_out =
          a `conn` b    = (a, b) `elem` conns state1 || a==b
          outs          = [ Output a (toValue (0.0 :: Double)) 
                          | (a,i) <- idx_out ]
+         withTasks     = not . Map.null $ tasks state1
      
-     trs <- simulateExt fds ioRandomSched conn procs1
+     trs <- simulateExt withTasks fds ioRandomSched conn procs1
      return (res, (state1, trs))
 
 -- | Internal simulator function. Blocks until we receive input from the
 -- input file descriptor, which drives the simulation forward.
-simulateExt :: (Fd, Fd)                          -- ^ (Input, Output)
-         -> Scheduler RandStateIO
-         -> ConnRel
-         -> ProcMap
-         -> RandStateIO [Transition]
-simulateExt (fdInput, fdOutput) sched conn procs =
+simulateExt :: Bool                              -- ^ With task assignments?
+            -> (Fd, Fd)                          -- ^ (Input, Output)
+            -> Scheduler RandStateIO
+            -> ConnRel
+            -> ProcMap
+            -> RandStateIO [Transition]
+simulateExt withTasks (fdInput, fdOutput) sched conn procs =
   do status <- readStatus fdInput
      case status of
        OK ->
@@ -1923,7 +1928,7 @@ simulateExt (fdInput, fdOutput) sched conn procs =
             newPrevIn <- copyVector vec
             modify $ \st -> st { prevIn = newPrevIn }
 
-            progress <- simulate1Ext sched conn newProcs []
+            progress <- simulate1Ext withTasks sched conn newProcs []
             case progress of
               Nothing ->
                 do logWrite "Ran out of alternatives, requesting halt."
@@ -1948,7 +1953,8 @@ simulateExt (fdInput, fdOutput) sched conn procs =
                    sendCDouble next fdOutput
                    sendVector output fdOutput
 
-                   (ts++) <$> simulateExt (fdInput, fdOutput) sched conn procs1
+                   (ts++) <$> 
+                     simulateExt withTasks (fdInput, fdOutput) sched conn procs1
 
        -- In case this happened we did not receive OK and we should die.
        DIE ->
@@ -1959,15 +1965,16 @@ simulateExt (fdInput, fdOutput) sched conn procs =
 -- advancing time. When @maximumProgress@ returns a @DELTA@ labeled
 -- transition, @simulate1Ext@ returns @Just (time, procs, transitions)@. If the
 -- simulator runs out of alternatives, @Nothing@ is returned.
-simulate1Ext :: Scheduler RandStateIO
+simulate1Ext :: Bool 
+             -> Scheduler RandStateIO
              -> ConnRel
              -> ProcMap
              -> [Transition]
              -> RandStateIO (Maybe (Time, ProcMap, [Transition]))
-simulate1Ext sched conn procs acc
+simulate1Ext withTasks sched conn procs acc
   | null alts = return Nothing
   | otherwise =
-    do mtrans <- maximumProgress conn False procs sched alts
+    do mtrans <- maximumProgress conn withTasks procs sched alts
        case mtrans of
          -- The trace finished - should we return a Just here?
          None -> 
@@ -1984,7 +1991,7 @@ simulate1Ext sched conn procs acc
           trans2 = tr { transError = w }
       in case transLabel tr of
           DELTA dt -> return $ Just (dt, procs2, trans2:acc)
-          _        -> simulate1Ext sched conn procs2 (trans2:acc)
+          _        -> simulate1Ext withTasks sched conn procs2 (trans2:acc)
 
 -- * Simulation entry-points.
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/NewARSim/Test.hs
+++ b/NewARSim/Test.hs
@@ -12,28 +12,34 @@ type IntPort p = DataElem Unqueued Int p
 type P a       = (a, a)
 type C         = P (IntPort Required)
 
+-- | @comp1@ runs every time "task1" is activated, and is mapped as the first
+-- runnable in that task.
 comp1 :: AUTOSAR (IntPort Provided)
 comp1 = atomic $ do
   a <- providedPort
   s <- interRunnableVariable 0
-  runnableT ["task1" :-> 0] (MinInterval 0) [TimingEvent 0.1] $ do
+  runnableT ["task1" :-> 0] (MinInterval 0) [TimingEvent 0.2] $ do
     Ok x <- rteIrvRead s
     rteWrite a x
     printlog "comp1" $ "write " ++ show x
     rteIrvWrite s (x + 1)
   return $ seal a 
 
+-- | A task assignment in which we allow @comp2@ to run every second activation
+-- of "task1".
 comp2 :: AUTOSAR (IntPort Provided)
 comp2 = atomic $ do
   a <- providedPort
   s <- interRunnableVariable 0
-  runnableT ["task1" :-> 1] (MinInterval 0) [TimingEvent 0.1] $ do
+  runnableT ["task1" :>> (1, 2)] (MinInterval 0) [TimingEvent 0.4] $ do
     Ok x <- rteIrvRead s
     rteWrite a x
     printlog "comp2" $ "write " ++ show x
     rteIrvWrite s ((x + 1) `mod` 3)
   return $ seal a 
 
+-- | Since @comp3@ depends on @comp2@ we would have to schedule it to run every
+-- second activation (and last) in "task1" if we were to map it to that task.
 comp3 :: AUTOSAR C
 comp3 = atomic $ do
   c1 <- requiredPort


### PR DESCRIPTION
- Runnables can be set to execute every `n`:th time the task is triggered:

``` haskell
runnableT ["my_task" :>> (ord, n)] ... -- Every nth
runnableT ["my_task" :-> ord] ... -- Translates to "my_task" :-> (ord, 1)
```
- Support for task assignments when running simulator in external mode.
